### PR TITLE
Add date and datetime entities

### DIFF
--- a/components/gecko_spa/__init__.py
+++ b/components/gecko_spa/__init__.py
@@ -5,7 +5,7 @@ from esphome.components import uart
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "switch", "select", "binary_sensor", "text_sensor"]
+AUTO_LOAD = ["climate", "datetime", "switch", "select", "binary_sensor", "text_sensor"]
 
 CONF_UART_ID = "uart_id"
 CONF_RESET_PIN = "reset_pin"

--- a/components/gecko_spa/datetime.py
+++ b/components/gecko_spa/datetime.py
@@ -1,0 +1,74 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import datetime
+from esphome.const import CONF_ID
+from . import gecko_spa_ns, GeckoSpa
+
+DEPENDENCIES = ["gecko_spa"]
+
+CONF_GECKO_SPA_ID = "gecko_spa_id"
+CONF_SENSOR_TYPE = "type"
+
+DATETIME_TYPES = {
+    "spa_time": "SPA_TIME",
+}
+DATE_TYPES = {
+    "rinse_filter": "RINSE_FILTER",
+    "clean_filter": "CLEAN_FILTER",
+    "change_water": "CHANGE_WATER",
+    "spa_checkup": "SPA_CHECKUP",
+}
+
+GeckoSpaDateTime = gecko_spa_ns.class_("GeckoSpaDateTime", datetime.DateTimeEntity, cg.Component)
+GeckoSpaDate = gecko_spa_ns.class_("GeckoSpaDate", datetime.DateEntity, cg.Component)
+
+_BASE_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_GECKO_SPA_ID): cv.use_id(GeckoSpa),
+        # cv.Required(CONF_SENSOR_TYPE): cv.enum(SENSOR_TYPES, lower=True),
+    }
+)
+
+_BASE_DATETIME_SCHEMA = _BASE_SCHEMA.extend(
+    {
+        cv.Required(CONF_SENSOR_TYPE): cv.enum(DATETIME_TYPES, lower=True),
+    }
+)
+
+_BASE_DATE_SCHEMA = _BASE_SCHEMA.extend(
+    {
+        cv.Required(CONF_SENSOR_TYPE): cv.enum(DATE_TYPES, lower=True),
+    }
+)
+
+CONFIG_SCHEMA = cv.Any(
+    datetime.datetime_schema(GeckoSpaDateTime).extend(_BASE_DATETIME_SCHEMA),
+    datetime.date_schema(GeckoSpaDate).extend(_BASE_DATE_SCHEMA),
+)
+
+
+async def to_code(config):
+    # "type" is a reservet config key for datetime entities, need to pull value and adjust config accordingly
+    sensor_type = config[CONF_SENSOR_TYPE]
+    if sensor_type in DATETIME_TYPES.keys():
+        config[CONF_SENSOR_TYPE] = "DATETIME"
+    elif sensor_type in DATE_TYPES.keys():
+        config[CONF_SENSOR_TYPE] = "DATE"
+    else:
+        raise ValueError(f"Unsupported sensor type: {sensor_type}")
+
+    parent = await cg.get_variable(config[CONF_GECKO_SPA_ID])
+    var = await datetime.new_datetime(config)
+
+    if sensor_type == "spa_time":
+        cg.add(parent.set_spa_time_datetime(var))
+    elif sensor_type == "rinse_filter":
+        cg.add(parent.set_rinse_filter_date(var))
+    elif sensor_type == "clean_filter":
+        cg.add(parent.set_clean_filter_date(var))
+    elif sensor_type == "change_water":
+        cg.add(parent.set_change_water_date(var))
+    elif sensor_type == "spa_checkup":
+        cg.add(parent.set_spa_checkup_date(var))
+    else:
+        raise ValueError(f"Unsupported sensor type: {sensor_type}")

--- a/components/gecko_spa/gecko_spa.cpp
+++ b/components/gecko_spa/gecko_spa.cpp
@@ -239,10 +239,15 @@ void GeckoSpa::process_i2c_message(const uint8_t *data, uint8_t len) {
 
     ESP_LOGD(TAG, "Spa clock: %02d/%02d %02d:%02d:%02d", day, month, hour, minute, second);
 
-    if (spa_time_sensor_) {
+    if (spa_time_text_sensor_) {
       char time_str[20];
       snprintf(time_str, sizeof(time_str), "%02d/%02d %02d:%02d:%02d", day, month, hour, minute, second);
-      spa_time_sensor_->publish_state(time_str);
+      spa_time_text_sensor_->publish_state(time_str);
+    }
+    if (spa_time_datetime_) {
+      datetime::DateTimeCall dt_call{spa_time_datetime_};
+      dt_call.set_datetime(2026, month, day, hour, minute, second);
+      // spa_time_datetime_->publish_state();
     }
 
     send_i2c_message(ACK_MESSAGE, 15);
@@ -478,24 +483,34 @@ void GeckoSpa::parse_notification_message(const uint8_t *data) {
     ESP_LOGI(TAG, "Notification %d: reset=%02d/%02d/%02d interval=%d due=%s",
              id, reset_day, reset_month, reset_year, interval, date_str);
 
-    text_sensor::TextSensor *sensor = nullptr;
+    text_sensor::TextSensor *t_sensor = nullptr;
+    datetime::DateEntity *d_sensor = nullptr;
     switch (id) {
       case 0x01:
-        sensor = rinse_filter_sensor_;
+        t_sensor = rinse_filter_text_sensor_;
+        d_sensor = rinse_filter_date_;
         break;
       case 0x02:
-        sensor = clean_filter_sensor_;
+        t_sensor = clean_filter_text_sensor_;
+        d_sensor = clean_filter_date_;
         break;
       case 0x03:
-        sensor = change_water_sensor_;
+        t_sensor = change_water_text_sensor_;
+        d_sensor = change_water_date_;
         break;
       case 0x04:
-        sensor = spa_checkup_sensor_;
+        t_sensor = spa_checkup_text_sensor_;
+        d_sensor = spa_checkup_date_;
         break;
     }
 
-    if (sensor) {
-      sensor->publish_state(date_str);
+    if (t_sensor) {
+      t_sensor->publish_state(date_str);
+    }
+    if (d_sensor) {
+      datetime::DateCall d_call{d_sensor};// = new datetime::DateCall(d_sensor);
+      d_call.set_date(reset_tm.tm_mday, reset_tm.tm_mon + 1, 1900 + reset_tm.tm_year);
+      // d_sensor->publish_state();
     }
   }
 }
@@ -526,6 +541,25 @@ void GeckoSpaClimate::control(const climate::ClimateCall &call) {
     this->target_temperature = temp;
     parent_->send_temperature_command(temp);
   }
+  this->publish_state();
+}
+
+// GeckoSpaDate implementation
+void GeckoSpaDateTime::control(const datetime::DateTimeCall &call) {
+  this->year_ = call.get_year().value();
+  this->month_ = call.get_month().value();
+  this->day_ = call.get_day().value();
+  this->hour_ = call.get_hour().value();
+  this->minute_ = call.get_minute().value();
+  this->second_ = call.get_second().value();
+  this->publish_state();
+}
+
+// GeckoSpaDate implementation
+void GeckoSpaDate::control(const datetime::DateCall &call) {
+  this->year_ = call.get_year().value();
+  this->month_ = call.get_month().value();
+  this->day_ = call.get_day().value();
   this->publish_state();
 }
 

--- a/components/gecko_spa/gecko_spa.h
+++ b/components/gecko_spa/gecko_spa.h
@@ -5,6 +5,8 @@
 #include "esphome/core/gpio.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/climate/climate.h"
+#include "esphome/components/datetime/date_entity.h"
+#include "esphome/components/datetime/datetime_entity.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
@@ -35,11 +37,16 @@ class GeckoSpa : public Component, public uart::UARTDevice {
     bs->publish_state(connected_);
   }
   void set_climate(climate::Climate *cl) { climate_ = cl; }
-  void set_rinse_filter_sensor(text_sensor::TextSensor *s) { rinse_filter_sensor_ = s; }
-  void set_clean_filter_sensor(text_sensor::TextSensor *s) { clean_filter_sensor_ = s; }
-  void set_change_water_sensor(text_sensor::TextSensor *s) { change_water_sensor_ = s; }
-  void set_spa_checkup_sensor(text_sensor::TextSensor *s) { spa_checkup_sensor_ = s; }
-  void set_spa_time_sensor(text_sensor::TextSensor *s) { spa_time_sensor_ = s; }
+  void set_rinse_filter_text_sensor(text_sensor::TextSensor *s) { rinse_filter_text_sensor_ = s; }
+  void set_clean_filter_text_sensor(text_sensor::TextSensor *s) { clean_filter_text_sensor_ = s; }
+  void set_change_water_text_sensor(text_sensor::TextSensor *s) { change_water_text_sensor_ = s; }
+  void set_spa_checkup_text_sensor(text_sensor::TextSensor *s) { spa_checkup_text_sensor_ = s; }
+  void set_spa_time_text_sensor(text_sensor::TextSensor *s) { spa_time_text_sensor_ = s; }
+  void set_rinse_filter_date(datetime::DateEntity *d) { rinse_filter_date_ = d; }
+  void set_clean_filter_date(datetime::DateEntity *d) { clean_filter_date_ = d; }
+  void set_change_water_date(datetime::DateEntity *d) { change_water_date_ = d; }
+  void set_spa_checkup_date(datetime::DateEntity *d) { spa_checkup_date_ = d; }
+  void set_spa_time_datetime(datetime::DateTimeEntity *dt) { spa_time_datetime_ = dt; }
   void set_reset_pin(GPIOPin *pin) { reset_pin_ = pin; }
 
   // Command methods
@@ -68,11 +75,16 @@ class GeckoSpa : public Component, public uart::UARTDevice {
   binary_sensor::BinarySensor *standby_sensor_{nullptr};
   binary_sensor::BinarySensor *connected_sensor_{nullptr};
   climate::Climate *climate_{nullptr};
-  text_sensor::TextSensor *rinse_filter_sensor_{nullptr};
-  text_sensor::TextSensor *clean_filter_sensor_{nullptr};
-  text_sensor::TextSensor *change_water_sensor_{nullptr};
-  text_sensor::TextSensor *spa_checkup_sensor_{nullptr};
-  text_sensor::TextSensor *spa_time_sensor_{nullptr};
+  text_sensor::TextSensor *rinse_filter_text_sensor_{nullptr};
+  text_sensor::TextSensor *clean_filter_text_sensor_{nullptr};
+  text_sensor::TextSensor *change_water_text_sensor_{nullptr};
+  text_sensor::TextSensor *spa_checkup_text_sensor_{nullptr};
+  text_sensor::TextSensor *spa_time_text_sensor_{nullptr};
+  datetime::DateEntity *rinse_filter_date_{nullptr};
+  datetime::DateEntity *clean_filter_date_{nullptr};
+  datetime::DateEntity *change_water_date_{nullptr};
+  datetime::DateEntity *spa_checkup_date_{nullptr};
+  datetime::DateTimeEntity *spa_time_datetime_{nullptr};
   GPIOPin *reset_pin_{nullptr};
 
   // State
@@ -122,6 +134,26 @@ class GeckoSpaClimate : public Component, public climate::Climate {
   void control(const climate::ClimateCall &call) override;
 
  protected:
+  GeckoSpa *parent_;
+};
+
+class GeckoSpaDateTime : public Component, public datetime::DateTimeEntity {
+ public:
+  void set_parent(GeckoSpa *parent) { parent_ = parent; }
+
+  void control(const datetime::DateTimeCall &call) override;
+
+ protected:
+  GeckoSpa *parent_;
+};
+
+class GeckoSpaDate : public Component, public datetime::DateEntity {
+ public:
+  void set_parent(GeckoSpa *parent) { parent_ = parent; }
+
+  void control(const datetime::DateCall &call) override;
+
+  protected:
   GeckoSpa *parent_;
 };
 

--- a/components/gecko_spa/text_sensor.py
+++ b/components/gecko_spa/text_sensor.py
@@ -31,12 +31,12 @@ async def to_code(config):
 
     sensor_type = config[CONF_SENSOR_TYPE]
     if sensor_type == "spa_time":
-        cg.add(parent.set_spa_time_sensor(var))
+        cg.add(parent.set_spa_time_text_sensor(var))
     elif sensor_type == "rinse_filter":
-        cg.add(parent.set_rinse_filter_sensor(var))
+        cg.add(parent.set_rinse_filter_text_sensor(var))
     elif sensor_type == "clean_filter":
-        cg.add(parent.set_clean_filter_sensor(var))
+        cg.add(parent.set_clean_filter_text_sensor(var))
     elif sensor_type == "change_water":
-        cg.add(parent.set_change_water_sensor(var))
+        cg.add(parent.set_change_water_text_sensor(var))
     elif sensor_type == "spa_checkup":
-        cg.add(parent.set_spa_checkup_sensor(var))
+        cg.add(parent.set_spa_checkup_text_sensor(var))


### PR DESCRIPTION
An attempt to add Date and DateTime entities representing spa state, to be used instead of the text_sensors.
Solving comment in #5 