### PR TITLE
Autodetect status message length to cope with different packs

### DIFF
--- a/components/gecko_spa/__init__.py
+++ b/components/gecko_spa/__init__.py
@@ -9,15 +9,23 @@ AUTO_LOAD = ["climate", "switch", "select", "binary_sensor", "text_sensor"]
 
 CONF_UART_ID = "uart_id"
 CONF_RESET_PIN = "reset_pin"
+CONF_NOTIF_DATE_FORMAT = "notif_date_format"
 
 gecko_spa_ns = cg.esphome_ns.namespace("gecko_spa")
 GeckoSpa = gecko_spa_ns.class_("GeckoSpa", cg.Component, uart.UARTDevice)
+
+NotifDateFormat = gecko_spa_ns.enum("NotifDateFormat", is_class=True)
+NOTIF_DATE_FORMATS = {
+    "Y-M-D": NotifDateFormat.Y_M_D,
+    "D-M-Y": NotifDateFormat.D_M_Y,
+}
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(GeckoSpa),
         cv.GenerateID(CONF_UART_ID): cv.use_id(uart.UARTComponent),
         cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_NOTIF_DATE_FORMAT, default="D-M-Y"): cv.enum(NOTIF_DATE_FORMATS, upper=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -32,3 +40,6 @@ async def to_code(config):
     if CONF_RESET_PIN in config:
         pin = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(pin))
+
+    if CONF_NOTIF_DATE_FORMAT in config:
+        cg.add(var.set_notif_date_format(config[CONF_NOTIF_DATE_FORMAT]))

--- a/components/gecko_spa/gecko_spa.cpp
+++ b/components/gecko_spa/gecko_spa.cpp
@@ -782,9 +782,16 @@ void GeckoSpa::parse_notification_message(const uint8_t *data) {
   for (int i = 0; i < 4; i++) {
     int offset = 16 + (i * 6);
     uint8_t id = data[offset];
-    uint8_t reset_day = data[offset + 1];
-    uint8_t reset_month = data[offset + 2];
-    uint8_t reset_year = data[offset + 3];  // 2-digit year
+    uint8_t reset_day, reset_month, reset_year;
+    if (notif_date_format_ == NotifDateFormat::D_M_Y) {
+      reset_day = data[offset + 1];
+      reset_month = data[offset + 2];
+      reset_year = data[offset + 3];  // 2-digit year
+    } else {
+      reset_year = data[offset + 1];  // 2-digit year
+      reset_month = data[offset + 2];
+      reset_day = data[offset + 3];
+    }
     uint16_t interval = data[offset + 4] | (data[offset + 5] << 8);
 
     if (id == 0 || interval == 0)

--- a/components/gecko_spa/gecko_spa.h
+++ b/components/gecko_spa/gecko_spa.h
@@ -64,6 +64,11 @@ static const GeckoLogOffsets GECKO_LOG_OFFSETS_V50 = {
 
 class GeckoSpaClimate;
 
+enum class NotifDateFormat : uint8_t {
+  Y_M_D = 0,
+  D_M_Y = 1
+};
+
 class GeckoSpa : public Component, public uart::UARTDevice {
  public:
   void setup() override;
@@ -101,6 +106,7 @@ class GeckoSpa : public Component, public uart::UARTDevice {
   void set_pack_type_sensor(text_sensor::TextSensor *s) { pack_type_sensor_ = s; }
   void set_pump_timer_sensor(sensor::Sensor *s) { pump_timer_sensor_ = s; }
   void set_reset_pin(GPIOPin *pin) { reset_pin_ = pin; }
+  void set_notif_date_format(NotifDateFormat format) { notif_date_format_ = format; }
 
   // Command methods
   void send_light_command(bool on);
@@ -152,6 +158,7 @@ class GeckoSpa : public Component, public uart::UARTDevice {
   text_sensor::TextSensor *pack_type_sensor_{nullptr};
   sensor::Sensor *pump_timer_sensor_{nullptr};
   GPIOPin *reset_pin_{nullptr};
+  NotifDateFormat notif_date_format_{NotifDateFormat::D_M_Y};
 
   // State
   bool light_state_{false};

--- a/esphome/spa-controller.yaml
+++ b/esphome/spa-controller.yaml
@@ -51,6 +51,7 @@ gecko_spa:
   id: spa
   uart_id: arduino_uart
   reset_pin: GPIO17  # Resets Arduino automatically on disconnect
+  notif_date_format: D-M-Y  # Change to Y-M-D if dates for reminders don't look right
 
 # Climate control
 climate:


### PR DESCRIPTION
The 162-byte status message length differs between spa packs.

This code determines the correct length for the local pack, and then applies that to calculate offsets for the embedded status message in the config+status packet.