### PR TITLE
Fix Pump 2 control by using shared pump demand byte

### DIFF
--- a/components/gecko_spa/gecko_spa.cpp
+++ b/components/gecko_spa/gecko_spa.cpp
@@ -95,30 +95,67 @@ void GeckoSpa::send_circ_command(bool on) {
 }
 
 void GeckoSpa::send_pump1_command(uint8_t state) {
-  // P1 function ID: 0x03
-  // State: 0=OFF, 2=ON/HIGH (P1 uses 0x02 for ON, not 0x01)
-  uint8_t state_val = (state == 0) ? 0x00 : 0x02;
+  uint8_t current = 0x00;
+
+  if (this->pump1_switch_ != nullptr && this->pump1_switch_->state)
+    current |= 0x02;
+
+  if (this->pump2_switch_ != nullptr && this->pump2_switch_->state)
+    current |= 0x08;
+
+  if (state == 0)
+    current &= ~0x02;
+  else
+    current |= 0x02;
 
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
-      0x01, 0x03, state_val, 0x00};
+      0x00, 0x00, 0x00, 0x00,
+      0x06,
+      0x46,
+      0x41, 0x42,
+      0x01,
+      0x03,
+      current,
+      0x00
+  };
+
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
-  ESP_LOGI(TAG, "Sent P1 state=%d command (val=0x%02X)", state, state_val);
+
+  ESP_LOGI(TAG, "Sent P1 command shared-pos=0x0103 state=%d combined=0x%02X", state, current);
 }
 
 void GeckoSpa::send_pump2_command(uint8_t state) {
-  // P2 function ID: 0x04 (EXPERIMENTAL - sequential from P1)
-  uint8_t state_val = (state == 0) ? 0x00 : 0x02;
+  uint8_t current = 0x00;
+
+  if (this->pump1_switch_ != nullptr && this->pump1_switch_->state)
+    current |= 0x02;
+
+  if (this->pump2_switch_ != nullptr && this->pump2_switch_->state)
+    current |= 0x08;
+
+  if (state == 0)
+    current &= ~0x08;
+  else
+    current |= 0x08;
 
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
-      0x01, 0x04, state_val, 0x00};
+      0x00, 0x00, 0x00, 0x00,
+      0x06,
+      0x46,
+      0x41, 0x42,
+      0x01,
+      0x03,
+      current,
+      0x00
+  };
+
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
-  ESP_LOGI(TAG, "Sent P2 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
+
+  ESP_LOGI(TAG, "Sent P2 command shared-pos=0x0103 state=%d combined=0x%02X", state, current);
 }
 
 void GeckoSpa::send_pump3_command(uint8_t state) {


### PR DESCRIPTION
More info in https://github.com/zteifel/esphome-gecko/issues/14#issuecomment-4689810018

This PR fixes Pump 2 control for packs where pump demand states are stored in a shared byte.

On my Gecko IN.YE-3-H3.0 / YE-3-CE with `inYT_C65.xml` / `inYT_S66.xml`, Pump 2 did not respond when treated as a separate sequential command position.

Testing showed that Pump 1 and Pump 2 share command position `0x0103`:

- Pump 1 HIGH = `0x02`
- Pump 2 HIGH = `0x08`
- Pump 1 + Pump 2 HIGH = `0x0A`
- Both OFF = `0x00`

The fix is to preserve the existing pump bits and only set/clear the relevant pump bit before sending the combined value to `0x0103`.

Confirmed test sequence:

- Pump 1 ON → status `[5]=02`, `P1=HIGH P2=OFF`
- Pump 2 ON → status `[5]=0A`, `P1=HIGH P2=HIGH`
- Pump 1 OFF → status `[5]=08`, `P1=OFF P2=HIGH`
- Pump 2 OFF → status `[5]=00`, `P1=OFF P2=OFF`