### PR TITLE
Fix commands to support different pack versions, and correct pump 2 command

### DIFF
--- a/components/gecko_spa/gecko_spa.cpp
+++ b/components/gecko_spa/gecko_spa.cpp
@@ -62,21 +62,11 @@ void GeckoSpa::loop() {
   }
 }
 
-void GeckoSpa::update_command_version(uint8_t *cmd) {
-  // Update version byte in command string, based on spa pack version.
-  // Version byte is at offset 12 for config/status messages, offset 13 for others
-  uint8_t version_offset = 14;
-
-  cmd[version_offset] = config_version_;
-  cmd[version_offset+1] = status_version_;
-}
-
 void GeckoSpa::send_light_command(bool on) {
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
+      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, config_version_, status_version_,
       0x01, 0x33, (uint8_t)(on ? 0x01 : 0x00), 0x00};
-  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent light %s command", on ? "ON" : "OFF");
@@ -85,9 +75,8 @@ void GeckoSpa::send_light_command(bool on) {
 void GeckoSpa::send_circ_command(bool on) {
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
+      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, config_version_, status_version_,
       0x01, 0x6B, (uint8_t)(on ? 0x01 : 0x00), 0x00};
-  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent circ %s command", on ? "ON" : "OFF");
@@ -96,55 +85,54 @@ void GeckoSpa::send_circ_command(bool on) {
 void GeckoSpa::send_pump1_command(uint8_t state) {
   // P1 function ID: 0x03
   // State: 0=OFF, 2=ON/HIGH (P1 uses 0x02 for ON, not 0x01)
-  uint8_t state_val = (state == 0) ? 0x00 : 0x02;
+  uint8_t state_val = (user_demand_state_ & 0xFC) | ((state == 0) ? 0x00 : 0x02);
 
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
+      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, config_version_, status_version_,
       0x01, 0x03, state_val, 0x00};
-  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P1 state=%d command (val=0x%02X)", state, state_val);
 }
 
 void GeckoSpa::send_pump2_command(uint8_t state) {
-  // P2 function ID: 0x04 (EXPERIMENTAL - sequential from P1)
-  uint8_t state_val = (state == 0) ? 0x00 : 0x02;
+  // P2 function ID: 0x03
+  // State: 0=OFF, 8=ON/HIGH (P2 uses 0x08 for ON, not 0x01)
+  uint8_t state_val = (user_demand_state_ & 0xF3) | ((state == 0) ? 0x00 : 0x08);
 
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
-      0x01, 0x04, state_val, 0x00};
-  update_command_version(cmd);
+      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, config_version_, status_version_,
+      0x01, 0x03, state_val, 0x00};
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
-  ESP_LOGI(TAG, "Sent P2 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
+  ESP_LOGI(TAG, "Sent P2 state=%d command (val=0x%02X)", state, state_val);
 }
 
 void GeckoSpa::send_pump3_command(uint8_t state) {
-  // P3 function ID: 0x05 (EXPERIMENTAL - sequential from P1)
-  uint8_t state_val = (state == 0) ? 0x00 : 0x02;
+  // P3 function ID: 0x03
+  // State: 0=OFF, 32=ON/HIGH (P3 uses 0x20 for ON, not 0x01)
+  uint8_t state_val = (user_demand_state_ & 0xCF) | ((state == 0) ? 0x00 : 0x20);
 
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
-      0x01, 0x05, state_val, 0x00};
-  update_command_version(cmd);
+      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, config_version_, status_version_,
+      0x01, 0x03, state_val, 0x00};
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P3 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
 }
 
 void GeckoSpa::send_pump4_command(uint8_t state) {
-  // P4 function ID: 0x06 (EXPERIMENTAL - sequential from P1)
-  uint8_t state_val = (state == 0) ? 0x00 : 0x02;
+  // P4 function ID: 0x03
+  // State: 0=OFF, 128=ON/HIGH (P4 uses 0x80 for ON, not 0x01)
+  uint8_t state_val = (user_demand_state_ & 0x3F) | ((state == 0) ? 0x00 : 0x80);
 
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
-      0x01, 0x06, state_val, 0x00};
-  update_command_version(cmd);
+      0x00, 0x00, 0x00, 0x00, 0x06, 0x46, config_version_, status_version_,
+      0x01, 0x03, state_val, 0x00};
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P4 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
@@ -169,9 +157,8 @@ void GeckoSpa::send_temperature_command(float temp_c) {
   uint8_t temp_raw = (uint8_t)((temp_c * 18.0) - 512.0);
   uint8_t cmd[21] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x07, 0x46, 0x52, 0x51,
+      0x00, 0x00, 0x00, 0x00, 0x07, 0x46, config_version_, status_version_,
       0x00, 0x01, 0x02, temp_raw, 0x00};
-  update_command_version(cmd);
   cmd[20] = calc_checksum(cmd, 21);
   send_i2c_message(cmd, 21);
   ESP_LOGI(TAG, "Sent temperature %.1f command (raw=%02X)", temp_c, temp_raw);
@@ -556,11 +543,11 @@ void GeckoSpa::parse_status_message(const uint8_t *data) {
   static const char* quiet_str[] = {"NOT_SET", "DRAIN", "SOAK", "OFF"};
 
   // User demand P1-P4 (2-bit fields in UdP1 byte)
-  uint8_t udP1_raw = data[b_udP1];
-  uint8_t udP1 = (udP1_raw >> 0) & 0x03;  // bits 0-1
-  uint8_t udP2 = (udP1_raw >> 2) & 0x03;  // bits 2-3
-  uint8_t udP3 = (udP1_raw >> 4) & 0x03;  // bits 4-5
-  uint8_t udP4 = (udP1_raw >> 6) & 0x03;  // bits 6-7
+  user_demand_state_ = data[b_udP1];
+  uint8_t udP1 = (user_demand_state_ >> 0) & 0x03;  // bits 0-1
+  uint8_t udP2 = (user_demand_state_ >> 2) & 0x03;  // bits 2-3
+  uint8_t udP3 = (user_demand_state_ >> 4) & 0x03;  // bits 4-5
+  uint8_t udP4 = (user_demand_state_ >> 6) & 0x03;  // bits 6-7
   static const char* pump_ud_str[] = {"OFF", "LO", "HI", "?"};
 
   // Device status byte (CP, BL, Heater, Waterfall)

--- a/components/gecko_spa/gecko_spa.cpp
+++ b/components/gecko_spa/gecko_spa.cpp
@@ -67,8 +67,8 @@ void GeckoSpa::update_command_version(uint8_t *cmd) {
   // Version byte is at offset 12 for config/status messages, offset 13 for others
   uint8_t version_offset = 14;
 
-  cmd[version_offset] = config_version;
-  cmd[version_offset+1] = status_version;
+  cmd[version_offset] = config_version_;
+  cmd[version_offset+1] = status_version_;
 }
 
 void GeckoSpa::send_light_command(bool on) {

--- a/components/gecko_spa/gecko_spa.cpp
+++ b/components/gecko_spa/gecko_spa.cpp
@@ -62,11 +62,21 @@ void GeckoSpa::loop() {
   }
 }
 
+void GeckoSpa::update_command_version(uint8_t *cmd) {
+  // Update version byte in command string, based on spa pack version.
+  // Version byte is at offset 12 for config/status messages, offset 13 for others
+  uint8_t version_offset = 14;
+
+  cmd[version_offset] = config_version;
+  cmd[version_offset+1] = status_version;
+}
+
 void GeckoSpa::send_light_command(bool on) {
   uint8_t cmd[20] = {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
       0x01, 0x33, (uint8_t)(on ? 0x01 : 0x00), 0x00};
+  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent light %s command", on ? "ON" : "OFF");
@@ -77,6 +87,7 @@ void GeckoSpa::send_circ_command(bool on) {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
       0x01, 0x6B, (uint8_t)(on ? 0x01 : 0x00), 0x00};
+  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent circ %s command", on ? "ON" : "OFF");
@@ -91,6 +102,7 @@ void GeckoSpa::send_pump1_command(uint8_t state) {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
       0x01, 0x03, state_val, 0x00};
+  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P1 state=%d command (val=0x%02X)", state, state_val);
@@ -104,6 +116,7 @@ void GeckoSpa::send_pump2_command(uint8_t state) {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
       0x01, 0x04, state_val, 0x00};
+  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P2 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
@@ -117,6 +130,7 @@ void GeckoSpa::send_pump3_command(uint8_t state) {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
       0x01, 0x05, state_val, 0x00};
+  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P3 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
@@ -130,6 +144,7 @@ void GeckoSpa::send_pump4_command(uint8_t state) {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x06, 0x46, 0x52, 0x51,
       0x01, 0x06, state_val, 0x00};
+  update_command_version(cmd);
   cmd[19] = calc_checksum(cmd, 20);
   send_i2c_message(cmd, 20);
   ESP_LOGI(TAG, "Sent P4 state=%d command (val=0x%02X) [EXPERIMENTAL]", state, state_val);
@@ -156,6 +171,7 @@ void GeckoSpa::send_temperature_command(float temp_c) {
       0x17, 0x0A, 0x00, 0x00, 0x00, 0x17, 0x09, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x07, 0x46, 0x52, 0x51,
       0x00, 0x01, 0x02, temp_raw, 0x00};
+  update_command_version(cmd);
   cmd[20] = calc_checksum(cmd, 21);
   send_i2c_message(cmd, 21);
   ESP_LOGI(TAG, "Sent temperature %.1f command (raw=%02X)", temp_c, temp_raw);

--- a/components/gecko_spa/gecko_spa.h
+++ b/components/gecko_spa/gecko_spa.h
@@ -169,6 +169,7 @@ class GeckoSpa : public Component, public uart::UARTDevice {
   bool standby_state_{false};
   bool connected_{false};
   bool first_status_received_{false};
+  uint8_t user_demand_state_{0};  // Bitfield from udP1-udP4 (P1-P4 user demand)
   uint8_t pump1_state_{0};   // 0=OFF, 1=HIGH, 2=LOW
   uint8_t pump2_state_{0};   // Read-only
   uint8_t pump3_state_{0};   // Read-only
@@ -206,7 +207,6 @@ class GeckoSpa : public Component, public uart::UARTDevice {
   uint16_t status_msg_len_{0};
   static const uint16_t MIN_STATUS_MSG_LEN{120};
 
-  void update_command_version(uint8_t *cmd); // Update version byte in command based on detected spa pack version
   uint8_t calc_checksum(const uint8_t *data, uint8_t len);
   void send_i2c_message(const uint8_t *data, uint8_t len);
   uint8_t hex_to_byte(char high, char low);

--- a/components/gecko_spa/gecko_spa.h
+++ b/components/gecko_spa/gecko_spa.h
@@ -206,6 +206,7 @@ class GeckoSpa : public Component, public uart::UARTDevice {
   uint16_t status_msg_len_{0};
   static const uint16_t MIN_STATUS_MSG_LEN{120};
 
+  void update_command_version(uint8_t *cmd); // Update version byte in command based on detected spa pack version
   uint8_t calc_checksum(const uint8_t *data, uint8_t len);
   void send_i2c_message(const uint8_t *data, uint8_t len);
   uint8_t hex_to_byte(char high, char low);


### PR DESCRIPTION
See discussion in #14 

Send correct pack version IDs in command strings (improved fix from previous PR)
Fix pump 2 command (tested)
Proposed pump 3 and 4 command fixes (untested, but follows logic for pumps 1+2, and UD state reporting format)